### PR TITLE
New enhancements

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -24,6 +24,7 @@ app_server <- function(input, output, session) {
       exclude_terms = "",
       include_type = "",
       language = "",
+      openaccess = "",
       result = list(
         include = tibble(doi = character(0)),
         exclude = tibble(doi = character(0))

--- a/R/mod_download.R
+++ b/R/mod_download.R
@@ -51,6 +51,7 @@ mod_download_server <- function(id, r) {
               exclude = as.character(r$filtered_result$exclude_terms),
               types = as.character(r$filtered_result$include_type),
               language = as.character(r$filtered_result$language),
+              openaccess = as.character(r$filtered_result$openaccess),
               `searchdate (yyyy-mm-dd)` = Sys.Date() %>% as.character()
             )
           )

--- a/R/mod_filter.R
+++ b/R/mod_filter.R
@@ -117,6 +117,12 @@ mod_filter_server <- function(id, r) {
           input$pubchoice %>%
             paste0(., collapse = " , ")
         
+        # open access
+        r$filtered_result$openaccess <-
+          if_else(
+            is.null(input$openaccess), "", "true"
+          )
+        
         # language
         r$filtered_result$language <-
           if_else(

--- a/R/mod_search.R
+++ b/R/mod_search.R
@@ -137,6 +137,7 @@ mod_search_server <- function(id, r) {
           exclude_terms = "",
           include_type = "",
           language = "",
+          openaccess = "",
           result = list(
             include = tibble(doi = character(0)),
             exclude = tibble(doi = character(0))

--- a/R/mod_search.R
+++ b/R/mod_search.R
@@ -51,7 +51,7 @@ mod_search_ui <- function(id) {
       12,
       dateInput(
         ns("searchdate_from"),
-        label = "Find articles online since (To note: Scopus will only filter as far as year) ...",
+        label = "Find articles online since:",
         value = Sys.Date() - 365,
         min = as.Date("1900-01-01"),
         max = Sys.Date()

--- a/R/ui_documentation.R
+++ b/R/ui_documentation.R
@@ -22,7 +22,7 @@ ui_documentation <- function() {
       ),
       p(
         "The Scopus search is implemented using the Elsevier ",
-        a(href = "https://dev.elsevier.com/documentation/ScopusSearchAPI.wadl", "Scopus Search API"),
+        a(href = "https://dev.elsevier.com/documentation/ScopusSearchAPI.wadl#d1e33", "Scopus Search API"),
         "."
       ),
       p(
@@ -60,7 +60,11 @@ ui_documentation <- function() {
       ),
       p(
         strong("Lang"), ": Language of the item (only available for items from 
-        Pubmed)."
+        Pubmed and Ebsco)."
+      ),
+      p(
+        strong("Open access"), ": Whether the publication is open access
+        (only available for items from Springer and Scopus)."
       ),
       p(
         strong("URL"), ": Link that will take you to the article page on the 


### PR DESCRIPTION
Closes #102 #101 #100.  

Updated the scopus documentation URL as it was out of date
Added term for open access toggle in documentation
Added open access column when downloaded so users can see if they have toggled to open access in their filtered search
Removed comment regarding scopus being only able to filter for up to a year.

Dashboard hosted on lit-fetch-dev at the moment.